### PR TITLE
refactor: simplify type bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-interface-blobstore"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-interface-http"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-interface-keyvalue"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-runtime-wasmtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,7 +2826,6 @@ version = "0.13.1"
 dependencies = [
  "anyhow",
  "async-nats",
- "async-trait",
  "bytes",
  "futures",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,10 +81,10 @@ wasmtime = { version = "18", default-features = false }
 wasmtime-wasi = { version = "18", default-features = false }
 wasmtime-wasi-http = { version = "18", default-features = false }
 wit-parser = { version = "0.13", default-features = false }
-wrpc-interface-blobstore = { version = "0.6", path = "./crates/interface-blobstore", default-features = false }
-wrpc-interface-http = { version = "0.13", path = "./crates/interface-http", default-features = false }
-wrpc-interface-keyvalue = { version = "0.5", path = "./crates/interface-keyvalue", default-features = false }
-wrpc-runtime-wasmtime = { version = "0.7", path = "./crates/runtime-wasmtime", default-features = false }
-wrpc-transport = { version = "0.16", path = "./crates/transport", default-features = false }
-wrpc-transport-nats = { version = "0.13", path = "./crates/transport-nats", default-features = false }
+wrpc-interface-blobstore = { version = "0.7", path = "./crates/interface-blobstore", default-features = false }
+wrpc-interface-http = { version = "0.14", path = "./crates/interface-http", default-features = false }
+wrpc-interface-keyvalue = { version = "0.6", path = "./crates/interface-keyvalue", default-features = false }
+wrpc-runtime-wasmtime = { version = "0.8", path = "./crates/runtime-wasmtime", default-features = false }
+wrpc-transport = { version = "0.17", path = "./crates/transport", default-features = false }
+wrpc-transport-nats = { version = "0.14", path = "./crates/transport-nats", default-features = false }
 wrpc-types = { version = "0.4", path = "./crates/types", default-features = false }

--- a/crates/interface-blobstore/Cargo.toml
+++ b/crates/interface-blobstore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-interface-blobstore"
-version = "0.6.0"
+version = "0.7.0"
 description = "wRPC blobstore interface"
 
 authors.workspace = true

--- a/crates/interface-blobstore/src/lib.rs
+++ b/crates/interface-blobstore/src/lib.rs
@@ -31,11 +31,11 @@ impl EncodeSync for ContainerMetadata {
 
 #[async_trait]
 impl Receive for ContainerMetadata {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -82,11 +82,11 @@ impl EncodeSync for ObjectMetadata {
 
 #[async_trait]
 impl Receive for ObjectMetadata {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -136,11 +136,11 @@ impl EncodeSync for ObjectId {
 
 #[async_trait]
 impl Receive for ObjectId {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {

--- a/crates/interface-blobstore/src/lib.rs
+++ b/crates/interface-blobstore/src/lib.rs
@@ -37,7 +37,7 @@ impl Receive for ContainerMetadata {
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let (name, payload) = Receive::receive_sync(payload, rx)
             .await
@@ -88,7 +88,7 @@ impl Receive for ObjectMetadata {
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let (name, payload) = Receive::receive_sync(payload, rx)
             .await
@@ -142,7 +142,7 @@ impl Receive for ObjectId {
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let (container, payload) = Receive::receive_sync(payload, rx)
             .await

--- a/crates/interface-blobstore/src/lib.rs
+++ b/crates/interface-blobstore/src/lib.rs
@@ -1,5 +1,4 @@
 use core::future::Future;
-use core::pin::Pin;
 
 use anyhow::Context as _;
 use async_trait::async_trait;
@@ -155,93 +154,149 @@ impl Receive for ObjectId {
     }
 }
 
-type StringInvocationStream<T> = Pin<
-    Box<
-        dyn Stream<
-                Item = anyhow::Result<
-                    AcceptedInvocation<
-                        <T as wrpc_transport::Client>::Context,
-                        String,
-                        <T as wrpc_transport::Client>::Subject,
-                        <<T as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
-                    >,
-                >,
-            > + Send,
-    >,
->;
-
-type ObjectIdInvocationStream<T> = Pin<
-    Box<
-        dyn Stream<
-                Item = anyhow::Result<
-                    AcceptedInvocation<
-                        <T as wrpc_transport::Client>::Context,
-                        ObjectId,
-                        <T as wrpc_transport::Client>::Subject,
-                        <<T as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
-                    >,
-                >,
-            > + Send,
-    >,
->;
-
 pub trait Blobstore: wrpc_transport::Client {
-    type ClearContainerInvocationStream;
-    type ContainerExistsInvocationStream;
-    type CreateContainerInvocationStream;
-    type DeleteContainerInvocationStream;
-    type GetContainerInfoInvocationStream;
-    type ListContainerObjectsInvocationStream;
-    type CopyObjectInvocationStream;
-    type DeleteObjectInvocationStream;
-    type DeleteObjectsInvocationStream;
-    type GetContainerDataInvocationStream;
-    type GetObjectInfoInvocationStream;
-    type HasObjectInvocationStream;
-    type MoveObjectInvocationStream;
-    type WriteContainerDataInvocationStream;
-
+    #[instrument(level = "trace", skip_all)]
     fn invoke_clear_container(
         &self,
         name: String,
-    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send;
+    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send {
+        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "clear-container", name)
+    }
+
+    #[instrument(level = "trace", skip_all)]
     fn serve_clear_container(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::ClearContainerInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                Item = anyhow::Result<
+                    AcceptedInvocation<
+                        <Self as wrpc_transport::Client>::Context,
+                        String,
+                        <Self as wrpc_transport::Client>::Subject,
+                        <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                    >,
+                >,
+            >,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "clear-container")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_container_exists(
         &self,
         name: String,
-    ) -> impl Future<Output = anyhow::Result<(Result<bool, String>, Self::Transmission)>> + Send;
+    ) -> impl Future<Output = anyhow::Result<(Result<bool, String>, Self::Transmission)>> + Send
+    {
+        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "container-exists", name)
+    }
+
+    #[instrument(level = "trace", skip_all)]
     fn serve_container_exists(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::ContainerExistsInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                Item = anyhow::Result<
+                    AcceptedInvocation<
+                        <Self as wrpc_transport::Client>::Context,
+                        String,
+                        <Self as wrpc_transport::Client>::Subject,
+                        <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                    >,
+                >,
+            >,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "container-exists")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_create_container(
         &self,
         name: String,
-    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send;
+    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send {
+        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "create-container", name)
+    }
+
+    #[instrument(level = "trace", skip_all)]
     fn serve_create_container(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::CreateContainerInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                Item = anyhow::Result<
+                    AcceptedInvocation<
+                        <Self as wrpc_transport::Client>::Context,
+                        String,
+                        <Self as wrpc_transport::Client>::Subject,
+                        <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                    >,
+                >,
+            >,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "create-container")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_delete_container(
         &self,
         name: String,
-    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send;
+    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send {
+        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "delete-container", name)
+    }
+
+    #[instrument(level = "trace", skip_all)]
     fn serve_delete_container(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::DeleteContainerInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                Item = anyhow::Result<
+                    AcceptedInvocation<
+                        <Self as wrpc_transport::Client>::Context,
+                        String,
+                        <Self as wrpc_transport::Client>::Subject,
+                        <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                    >,
+                >,
+            >,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "delete-container")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_get_container_info(
         &self,
         name: String,
     ) -> impl Future<Output = anyhow::Result<(Result<ContainerMetadata, String>, Self::Transmission)>>
-           + Send;
+           + Send {
+        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "get-container-info", name)
+    }
+    #[instrument(level = "trace", skip_all)]
     fn serve_get_container_info(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::GetContainerInfoInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                Item = anyhow::Result<
+                    AcceptedInvocation<
+                        <Self as wrpc_transport::Client>::Context,
+                        String,
+                        <Self as wrpc_transport::Client>::Subject,
+                        <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                    >,
+                >,
+            >,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "get-container-info")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_list_container_objects(
         &self,
         name: String,
@@ -255,37 +310,123 @@ pub trait Blobstore: wrpc_transport::Client {
             >,
             Self::Transmission,
         )>,
-    > + Send;
+    > + Send {
+        self.invoke_static(
+            "wrpc:blobstore/blobstore@0.1.0",
+            "list-container-objects",
+            (name, limit, offset),
+        )
+    }
+    #[instrument(level = "trace", skip_all)]
     fn serve_list_container_objects(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::ListContainerObjectsInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                Item = anyhow::Result<
+                    AcceptedInvocation<
+                        Self::Context,
+                        (String, Option<u64>, Option<u64>),
+                        Self::Subject,
+                        <Self::Acceptor as Acceptor>::Transmitter,
+                    >,
+                >,
+            >,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "list-container-objects")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_copy_object(
         &self,
         src: ObjectId,
         dest: ObjectId,
-    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send;
+    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send {
+        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "copy-object", (src, dest))
+    }
+
+    #[instrument(level = "trace", skip_all)]
     fn serve_copy_object(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::CopyObjectInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                Item = anyhow::Result<
+                    AcceptedInvocation<
+                        Self::Context,
+                        (ObjectId, ObjectId),
+                        Self::Subject,
+                        <Self::Acceptor as Acceptor>::Transmitter,
+                    >,
+                >,
+            >,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "copy-object")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_delete_object(
         &self,
         id: ObjectId,
-    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send;
+    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send {
+        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "delete-object", id)
+    }
+    #[instrument(level = "trace", skip_all)]
     fn serve_delete_object(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::DeleteObjectInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                    Item = anyhow::Result<
+                        AcceptedInvocation<
+                            <Self as wrpc_transport::Client>::Context,
+                            ObjectId,
+                            <Self as wrpc_transport::Client>::Subject,
+                            <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                        >,
+                    >,
+                > + Send,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "delete-object")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_delete_objects(
         &self,
         container: String,
         objects: Vec<String>,
-    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send;
+    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send {
+        self.invoke_static(
+            "wrpc:blobstore/blobstore@0.1.0",
+            "delete-objects",
+            (container, objects),
+        )
+    }
+
+    #[instrument(level = "trace", skip_all)]
     fn serve_delete_objects(
         &self,
-    ) -> impl Future<Output = anyhow::Result<Self::DeleteObjectsInvocationStream>> + Send;
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                    Item = anyhow::Result<
+                        AcceptedInvocation<
+                            <Self as wrpc_transport::Client>::Context,
+                            (String, Vec<String>),
+                            <Self as wrpc_transport::Client>::Subject,
+                            <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                        >,
+                    >,
+                > + Send,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "delete-objects")
+    }
 
+    #[instrument(level = "trace", skip_all)]
     fn invoke_get_container_data(
         &self,
         id: ObjectId,
@@ -293,335 +434,127 @@ pub trait Blobstore: wrpc_transport::Client {
         end: u64,
     ) -> impl Future<
         Output = anyhow::Result<(Result<IncomingInputStream, String>, Self::Transmission)>,
-    > + Send;
-    fn serve_get_container_data(
-        &self,
-    ) -> impl Future<Output = anyhow::Result<Self::GetContainerDataInvocationStream>> + Send;
-
-    fn invoke_get_object_info(
-        &self,
-        id: ObjectId,
-    ) -> impl Future<Output = anyhow::Result<(Result<ObjectMetadata, String>, Self::Transmission)>> + Send;
-    fn serve_get_object_info(
-        &self,
-    ) -> impl Future<Output = anyhow::Result<Self::GetObjectInfoInvocationStream>> + Send;
-
-    fn invoke_has_object(
-        &self,
-        id: ObjectId,
-    ) -> impl Future<Output = anyhow::Result<(Result<bool, String>, Self::Transmission)>> + Send;
-    fn serve_has_object(
-        &self,
-    ) -> impl Future<Output = anyhow::Result<Self::HasObjectInvocationStream>> + Send;
-
-    fn invoke_move_object(
-        &self,
-        src: ObjectId,
-        dest: ObjectId,
-    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send;
-    fn serve_move_object(
-        &self,
-    ) -> impl Future<Output = anyhow::Result<Self::MoveObjectInvocationStream>> + Send;
-
-    fn invoke_write_container_data(
-        &self,
-        id: ObjectId,
-        data: impl Stream<Item = Bytes> + Send + 'static,
-    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send;
-    fn serve_write_container_data(
-        &self,
-    ) -> impl Future<Output = anyhow::Result<Self::WriteContainerDataInvocationStream>> + Send;
-}
-
-impl<T: wrpc_transport::Client> Blobstore for T {
-    type ClearContainerInvocationStream = StringInvocationStream<T>;
-    type ContainerExistsInvocationStream = StringInvocationStream<T>;
-    type CreateContainerInvocationStream = StringInvocationStream<T>;
-    type DeleteContainerInvocationStream = StringInvocationStream<T>;
-    type GetContainerInfoInvocationStream = StringInvocationStream<T>;
-    type ListContainerObjectsInvocationStream = Pin<
-        Box<
-            dyn Stream<
-                    Item = anyhow::Result<
-                        AcceptedInvocation<
-                            T::Context,
-                            (String, Option<u64>, Option<u64>),
-                            T::Subject,
-                            <T::Acceptor as Acceptor>::Transmitter,
-                        >,
-                    >,
-                > + Send,
-        >,
-    >;
-    type CopyObjectInvocationStream = Pin<
-        Box<
-            dyn Stream<
-                    Item = anyhow::Result<
-                        AcceptedInvocation<
-                            T::Context,
-                            (ObjectId, ObjectId),
-                            T::Subject,
-                            <T::Acceptor as Acceptor>::Transmitter,
-                        >,
-                    >,
-                > + Send,
-        >,
-    >;
-    type DeleteObjectInvocationStream = ObjectIdInvocationStream<T>;
-    type DeleteObjectsInvocationStream = Pin<
-        Box<
-            dyn Stream<
-                    Item = anyhow::Result<
-                        AcceptedInvocation<
-                            T::Context,
-                            (String, Vec<String>),
-                            T::Subject,
-                            <T::Acceptor as Acceptor>::Transmitter,
-                        >,
-                    >,
-                > + Send,
-        >,
-    >;
-    type GetContainerDataInvocationStream = Pin<
-        Box<
-            dyn Stream<
-                    Item = anyhow::Result<
-                        AcceptedInvocation<
-                            T::Context,
-                            (ObjectId, u64, u64),
-                            T::Subject,
-                            <T::Acceptor as Acceptor>::Transmitter,
-                        >,
-                    >,
-                > + Send,
-        >,
-    >;
-    type GetObjectInfoInvocationStream = ObjectIdInvocationStream<T>;
-    type HasObjectInvocationStream = ObjectIdInvocationStream<T>;
-    type MoveObjectInvocationStream = Pin<
-        Box<
-            dyn Stream<
-                    Item = anyhow::Result<
-                        AcceptedInvocation<
-                            T::Context,
-                            (ObjectId, ObjectId),
-                            T::Subject,
-                            <T::Acceptor as Acceptor>::Transmitter,
-                        >,
-                    >,
-                > + Send,
-        >,
-    >;
-    type WriteContainerDataInvocationStream = Pin<
-        Box<
-            dyn Stream<
-                    Item = anyhow::Result<
-                        AcceptedInvocation<
-                            T::Context,
-                            (ObjectId, IncomingInputStream),
-                            T::Subject,
-                            <T::Acceptor as Acceptor>::Transmitter,
-                        >,
-                    >,
-                > + Send,
-        >,
-    >;
-
-    async fn invoke_clear_container(
-        &self,
-        name: String,
-    ) -> anyhow::Result<(Result<(), String>, T::Transmission)> {
-        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "clear-container", name)
-            .await
-    }
-    async fn serve_clear_container(&self) -> anyhow::Result<Self::ClearContainerInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "clear-container")
-            .await
-    }
-
-    async fn invoke_container_exists(
-        &self,
-        name: String,
-    ) -> anyhow::Result<(Result<bool, String>, T::Transmission)> {
-        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "container-exists", name)
-            .await
-    }
-    async fn serve_container_exists(
-        &self,
-    ) -> anyhow::Result<Self::ContainerExistsInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "container-exists")
-            .await
-    }
-
-    async fn invoke_create_container(
-        &self,
-        name: String,
-    ) -> anyhow::Result<(Result<(), String>, T::Transmission)> {
-        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "create-container", name)
-            .await
-    }
-    async fn serve_create_container(
-        &self,
-    ) -> anyhow::Result<Self::CreateContainerInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "create-container")
-            .await
-    }
-
-    async fn invoke_delete_container(
-        &self,
-        name: String,
-    ) -> anyhow::Result<(Result<(), String>, T::Transmission)> {
-        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "delete-container", name)
-            .await
-    }
-    async fn serve_delete_container(
-        &self,
-    ) -> anyhow::Result<Self::DeleteContainerInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "delete-container")
-            .await
-    }
-
-    async fn invoke_get_container_info(
-        &self,
-        name: String,
-    ) -> anyhow::Result<(Result<ContainerMetadata, String>, T::Transmission)> {
-        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "get-container-info", name)
-            .await
-    }
-    async fn serve_get_container_info(
-        &self,
-    ) -> anyhow::Result<Self::GetContainerInfoInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "get-container-info")
-            .await
-    }
-
-    async fn invoke_list_container_objects(
-        &self,
-        name: String,
-        limit: Option<u64>,
-        offset: Option<u64>,
-    ) -> anyhow::Result<(
-        Result<Box<dyn Stream<Item = anyhow::Result<Vec<String>>> + Send + Sync + Unpin>, String>,
-        Self::Transmission,
-    )> {
-        self.invoke_static(
-            "wrpc:blobstore/blobstore@0.1.0",
-            "list-container-objects",
-            (name, limit, offset),
-        )
-        .await
-    }
-    async fn serve_list_container_objects(
-        &self,
-    ) -> anyhow::Result<Self::ListContainerObjectsInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "list-container-objects")
-            .await
-    }
-
-    async fn invoke_copy_object(
-        &self,
-        src: ObjectId,
-        dest: ObjectId,
-    ) -> anyhow::Result<(Result<(), String>, Self::Transmission)> {
-        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "copy-object", (src, dest))
-            .await
-    }
-    async fn serve_copy_object(&self) -> anyhow::Result<Self::CopyObjectInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "copy-object")
-            .await
-    }
-
-    async fn invoke_delete_object(
-        &self,
-        id: ObjectId,
-    ) -> anyhow::Result<(Result<(), String>, Self::Transmission)> {
-        self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "delete-object", id)
-            .await
-    }
-    async fn serve_delete_object(&self) -> anyhow::Result<Self::DeleteObjectInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "delete-object")
-            .await
-    }
-
-    async fn invoke_delete_objects(
-        &self,
-        container: String,
-        objects: Vec<String>,
-    ) -> anyhow::Result<(Result<(), String>, Self::Transmission)> {
-        self.invoke_static(
-            "wrpc:blobstore/blobstore@0.1.0",
-            "delete-objects",
-            (container, objects),
-        )
-        .await
-    }
-    async fn serve_delete_objects(&self) -> anyhow::Result<Self::DeleteObjectsInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "delete-objects")
-            .await
-    }
-
-    async fn invoke_get_container_data(
-        &self,
-        id: ObjectId,
-        start: u64,
-        end: u64,
-    ) -> anyhow::Result<(Result<IncomingInputStream, String>, Self::Transmission)> {
+    > + Send {
         self.invoke_static(
             "wrpc:blobstore/blobstore@0.1.0",
             "get-container-data",
             (id, start, end),
         )
-        .await
     }
-    async fn serve_get_container_data(
+
+    #[instrument(level = "trace", skip_all)]
+    fn serve_get_container_data(
         &self,
-    ) -> anyhow::Result<Self::GetContainerDataInvocationStream> {
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                    Item = anyhow::Result<
+                        AcceptedInvocation<
+                            <Self as wrpc_transport::Client>::Context,
+                            (ObjectId, u64, u64),
+                            <Self as wrpc_transport::Client>::Subject,
+                            <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                        >,
+                    >,
+                > + Send,
+        >,
+    > + Send {
         self.serve_static("wrpc:blobstore/blobstore@0.1.0", "get-container-data")
-            .await
     }
 
-    async fn invoke_get_object_info(
+    #[instrument(level = "trace", skip_all)]
+    fn invoke_get_object_info(
         &self,
         id: ObjectId,
-    ) -> anyhow::Result<(Result<ObjectMetadata, String>, Self::Transmission)> {
+    ) -> impl Future<Output = anyhow::Result<(Result<ObjectMetadata, String>, Self::Transmission)>> + Send
+    {
         self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "get-object-info", id)
-            .await
-    }
-    async fn serve_get_object_info(&self) -> anyhow::Result<Self::GetObjectInfoInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "get-object-info")
-            .await
     }
 
-    async fn invoke_has_object(
+    #[instrument(level = "trace", skip_all)]
+    fn serve_get_object_info(
+        &self,
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                    Item = anyhow::Result<
+                        AcceptedInvocation<
+                            <Self as wrpc_transport::Client>::Context,
+                            ObjectId,
+                            <Self as wrpc_transport::Client>::Subject,
+                            <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                        >,
+                    >,
+                > + Send,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "get-object-info")
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    fn invoke_has_object(
         &self,
         id: ObjectId,
-    ) -> anyhow::Result<(Result<bool, String>, Self::Transmission)> {
+    ) -> impl Future<Output = anyhow::Result<(Result<bool, String>, Self::Transmission)>> + Send
+    {
         self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "has-object", id)
-            .await
-    }
-    async fn serve_has_object(&self) -> anyhow::Result<Self::HasObjectInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "has-object")
-            .await
     }
 
-    async fn invoke_move_object(
+    #[instrument(level = "trace", skip_all)]
+    fn serve_has_object(
+        &self,
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                    Item = anyhow::Result<
+                        AcceptedInvocation<
+                            <Self as wrpc_transport::Client>::Context,
+                            ObjectId,
+                            <Self as wrpc_transport::Client>::Subject,
+                            <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                        >,
+                    >,
+                > + Send,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "has-object")
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    fn invoke_move_object(
         &self,
         src: ObjectId,
         dest: ObjectId,
-    ) -> anyhow::Result<(Result<(), String>, Self::Transmission)> {
+    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send {
         self.invoke_static("wrpc:blobstore/blobstore@0.1.0", "move-object", (src, dest))
-            .await
-    }
-    async fn serve_move_object(&self) -> anyhow::Result<Self::MoveObjectInvocationStream> {
-        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "move-object")
-            .await
     }
 
-    async fn invoke_write_container_data(
+    #[instrument(level = "trace", skip_all)]
+    fn serve_move_object(
+        &self,
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                    Item = anyhow::Result<
+                        AcceptedInvocation<
+                            <Self as wrpc_transport::Client>::Context,
+                            (ObjectId, ObjectId),
+                            <Self as wrpc_transport::Client>::Subject,
+                            <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                        >,
+                    >,
+                > + Send,
+        >,
+    > + Send {
+        self.serve_static("wrpc:blobstore/blobstore@0.1.0", "move-object")
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    fn invoke_write_container_data(
         &self,
         id: ObjectId,
         data: impl Stream<Item = Bytes> + Send + 'static,
-    ) -> anyhow::Result<(Result<(), String>, Self::Transmission)> {
+    ) -> impl Future<Output = anyhow::Result<(Result<(), String>, Self::Transmission)>> + Send {
         self.invoke_static(
             "wrpc:blobstore/blobstore@0.1.0",
             "write-container-data",
@@ -632,12 +565,27 @@ impl<T: wrpc_transport::Client> Blobstore for T {
                 )),
             ),
         )
-        .await
     }
-    async fn serve_write_container_data(
+
+    #[instrument(level = "trace", skip_all)]
+    fn serve_write_container_data(
         &self,
-    ) -> anyhow::Result<Self::WriteContainerDataInvocationStream> {
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                    Item = anyhow::Result<
+                        AcceptedInvocation<
+                            <Self as wrpc_transport::Client>::Context,
+                            (ObjectId, IncomingInputStream),
+                            <Self as wrpc_transport::Client>::Subject,
+                            <<Self as wrpc_transport::Client>::Acceptor as Acceptor>::Transmitter,
+                        >,
+                    >,
+                > + Send,
+        >,
+    > + Send {
         self.serve_static("wrpc:blobstore/blobstore@0.1.0", "write-container-data")
-            .await
     }
 }
+
+impl<T: wrpc_transport::Client> Blobstore for T {}

--- a/crates/interface-http/Cargo.toml
+++ b/crates/interface-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-interface-http"
-version = "0.13.1"
+version = "0.14.0"
 description = "wRPC HTTP interface"
 
 authors.workspace = true

--- a/crates/interface-http/src/lib.rs
+++ b/crates/interface-http/src/lib.rs
@@ -158,13 +158,13 @@ impl EncodeSync for Method {
 impl Receive for Method {
     async fn receive<'a, T>(
         payload: impl Buf + Send + 'a,
-        rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
+        mut rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
-        let (discriminant, payload) = receive_discriminant(payload, rx).await?;
+        let (discriminant, payload) = receive_discriminant(payload, &mut rx).await?;
         match discriminant {
             0 => Ok((Self::Get, payload)),
             1 => Ok((Self::Head, payload)),
@@ -233,13 +233,13 @@ impl EncodeSync for Scheme {
 impl Receive for Scheme {
     async fn receive<'a, T>(
         payload: impl Buf + Send + 'a,
-        rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
+        mut rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
-        let (discriminant, payload) = receive_discriminant(payload, rx).await?;
+        let (discriminant, payload) = receive_discriminant(payload, &mut rx).await?;
         match discriminant {
             0 => Ok((Self::HTTP, payload)),
             1 => Ok((Self::HTTPS, payload)),
@@ -293,7 +293,7 @@ impl Receive for DnsErrorPayload {
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let (rcode, payload) = Receive::receive_sync(payload, rx)
             .await
@@ -368,7 +368,7 @@ impl Receive for TlsAlertReceivedPayload {
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let (alert_id, payload) = Receive::receive_sync(payload, rx)
             .await
@@ -445,7 +445,7 @@ impl Receive for FieldSizePayload {
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let (field_name, payload) = Receive::receive_sync(payload, rx)
             .await
@@ -725,13 +725,13 @@ impl EncodeSync for ErrorCode {
 impl Receive for ErrorCode {
     async fn receive<'a, T>(
         payload: impl Buf + Send + 'a,
-        rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
+        mut rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
-        let (discriminant, payload) = receive_discriminant(payload, rx).await?;
+        let (discriminant, payload) = receive_discriminant(payload, &mut rx).await?;
         match discriminant {
             0 => Ok((Self::DnsTimeout, payload)),
             1 => {
@@ -855,7 +855,7 @@ impl Receive for RequestOptions {
         _sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let (connect_timeout, payload) = Receive::receive_sync(payload, rx)
             .await
@@ -1229,7 +1229,7 @@ impl Receive for IncomingRequest {
         sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let mut sub = sub
             .map(AsyncSubscription::try_unwrap_record)
@@ -1451,7 +1451,7 @@ impl Receive for IncomingResponse {
         sub: Option<AsyncSubscription<T>>,
     ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
-        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static,
     {
         let mut sub = sub
             .map(AsyncSubscription::try_unwrap_record)

--- a/crates/interface-http/src/lib.rs
+++ b/crates/interface-http/src/lib.rs
@@ -1558,7 +1558,6 @@ pub trait IncomingHandler: wrpc_transport::Client {
             let (response, tx, errors) = self.invoke_handle_http(request).await?;
             match response {
                 Ok(response) => {
-                    let response: hyper::Response<IncomingBody<IncomingInputStream, IncomingFields>> = response.try_into().context("failed to convert incoming `wrpc:http/types.response` to hyper outgoing response")?;
                     let (parts, body) = response.into_parts();
                     Ok((Ok(hyper::Response::from_parts(parts, body)), tx, errors))
                 }

--- a/crates/interface-http/src/lib.rs
+++ b/crates/interface-http/src/lib.rs
@@ -156,11 +156,11 @@ impl EncodeSync for Method {
 
 #[async_trait]
 impl Receive for Method {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -231,11 +231,11 @@ impl EncodeSync for Scheme {
 
 #[async_trait]
 impl Receive for Scheme {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -287,11 +287,11 @@ impl EncodeSync for DnsErrorPayload {
 
 #[async_trait]
 impl Receive for DnsErrorPayload {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -362,11 +362,11 @@ impl EncodeSync for TlsAlertReceivedPayload {
 
 #[async_trait]
 impl Receive for TlsAlertReceivedPayload {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -439,11 +439,11 @@ impl EncodeSync for FieldSizePayload {
 
 #[async_trait]
 impl Receive for FieldSizePayload {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -723,11 +723,11 @@ impl EncodeSync for ErrorCode {
 
 #[async_trait]
 impl Receive for ErrorCode {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -849,11 +849,11 @@ impl EncodeSync for RequestOptions {
 
 #[async_trait]
 impl Receive for RequestOptions {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         _sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -1223,11 +1223,11 @@ impl Subscribe for IncomingRequest {
 
 #[async_trait]
 impl Receive for IncomingRequest {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {
@@ -1445,11 +1445,11 @@ impl Subscribe for IncomingResponse {
 
 #[async_trait]
 impl Receive for IncomingResponse {
-    async fn receive<T>(
-        payload: impl Buf + Send + 'static,
+    async fn receive<'a, T>(
+        payload: impl Buf + Send + 'a,
         rx: &mut (impl Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin),
         sub: Option<AsyncSubscription<T>>,
-    ) -> anyhow::Result<(Self, Box<dyn Buf + Send>)>
+    ) -> anyhow::Result<(Self, Box<dyn Buf + Send + 'a>)>
     where
         T: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
     {

--- a/crates/interface-keyvalue/Cargo.toml
+++ b/crates/interface-keyvalue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-interface-keyvalue"
-version = "0.5.0"
+version = "0.6.0"
 description = "wRPC keyvalue interface"
 
 authors.workspace = true

--- a/crates/runtime-wasmtime/Cargo.toml
+++ b/crates/runtime-wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-runtime-wasmtime"
-version = "0.7.0"
+version = "0.8.0"
 description = "wRPC wasmtime integration"
 
 authors.workspace = true

--- a/crates/transport-nats/Cargo.toml
+++ b/crates/transport-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport-nats"
-version = "0.13.1"
+version = "0.14.0"
 description = "wRPC NATS transport"
 
 authors.workspace = true

--- a/crates/transport-nats/Cargo.toml
+++ b/crates/transport-nats/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 async-nats = { workspace = true }
-async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/crates/transport-nats/src/lib.rs
+++ b/crates/transport-nats/src/lib.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context as _};
 use async_nats::subject::ToSubject;
 use async_nats::{HeaderMap, ServerInfo, StatusCode};
-use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use futures::future::FutureExt as _;
 use futures::{Stream, StreamExt};
@@ -250,7 +249,6 @@ impl Subscriber {
     }
 }
 
-#[async_trait]
 impl wrpc_transport::Subscriber for Subscriber {
     type Subject = Subject;
     type Stream = ByteSubscription;
@@ -342,7 +340,6 @@ impl Display for PublishError {
     }
 }
 
-#[async_trait]
 impl wrpc_transport::Transmitter for Transmitter {
     type Subject = Subject;
     type PublishError = PublishError;

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport"
-version = "0.16.0"
+version = "0.17.0"
 description = "wRPC core transport functionality"
 
 authors.workspace = true

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -3440,7 +3440,7 @@ pub trait Client: Sync {
                 } => {
                     trace!("received results");
                     let (results, _) = results?;
-                    return Ok((results, tx))
+                    Ok((results, tx))
                 }
                 payload = error_rx.try_next() => {
                     let payload = payload
@@ -3524,7 +3524,7 @@ pub trait Client: Sync {
                 } => {
                     trace!("received results");
                     let (results, _) = results?;
-                    return Ok((results, tx))
+                    Ok((results, tx))
                 }
                 payload = error_rx.next() => {
                     let payload = payload

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 use core::iter::zip;
+use core::pin::pin;
 use core::str;
 use core::time::Duration;
 
@@ -78,7 +79,7 @@ async fn loopback_dynamic(
             results: results_ty,
         } => {
             info!("serve function");
-            let mut invocations = client
+            let invocations = client
                 .serve_dynamic("wrpc:wrpc/test-dynamic", name, params_ty)
                 .await
                 .context("failed to serve static function")?;
@@ -90,7 +91,7 @@ async fn loopback_dynamic(
                         result_subject,
                         transmitter,
                         ..
-                    } = invocations
+                    } = pin!(invocations)
                         .try_next()
                         .await
                         .with_context(|| "unexpected end of invocation stream".to_string())?
@@ -1078,7 +1079,7 @@ async fn nats() -> anyhow::Result<()> {
         ));
     }
 
-    let mut unit_invocations = client
+    let unit_invocations = client
         .serve_static::<()>("wrpc:wrpc/test-static", "unit_unit")
         .await
         .context("failed to serve")?;
@@ -1089,7 +1090,7 @@ async fn nats() -> anyhow::Result<()> {
                 result_subject,
                 transmitter,
                 ..
-            } = unit_invocations
+            } = pin!(unit_invocations)
                 .try_next()
                 .await
                 .context("failed to receive invocation")?
@@ -1120,7 +1121,8 @@ async fn nats() -> anyhow::Result<()> {
             .local_addr()
             .context("failed to query listener local address")?;
 
-        let mut invocations = client.serve_handle().await.context("failed to serve")?;
+        let invocations = client.serve_handle().await.context("failed to serve")?;
+        let mut invocations = pin!(invocations);
         try_join!(
             async {
                 let AcceptedInvocation {
@@ -1373,7 +1375,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_http::OutgoingHandler;
 
-        let mut invocations = client.serve_handle().await.context("failed to serve")?;
+        let invocations = client.serve_handle().await.context("failed to serve")?;
         try_join!(
             async {
                 let AcceptedInvocation {
@@ -1393,7 +1395,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1523,10 +1525,11 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_clear_container()
             .await
             .context("failed to serve `clear-container`")?;
+        let mut invocations = pin!(invocations);
         try_join!(
             async {
                 let AcceptedInvocation {
@@ -1602,7 +1605,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_container_exists()
             .await
             .context("failed to serve `container-exists`")?;
@@ -1613,7 +1616,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1645,7 +1648,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_create_container()
             .await
             .context("failed to serve `create-container`")?;
@@ -1656,7 +1659,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1687,7 +1690,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_delete_container()
             .await
             .context("failed to serve `delete-container`")?;
@@ -1698,7 +1701,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1729,7 +1732,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_get_container_info()
             .await
             .context("failed to serve `get-container-info`")?;
@@ -1740,7 +1743,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1779,7 +1782,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_list_container_objects()
             .await
             .context("failed to serve `list-container-objects`")?;
@@ -1790,7 +1793,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1834,7 +1837,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_copy_object()
             .await
             .context("failed to serve `copy-object`")?;
@@ -1845,7 +1848,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1898,7 +1901,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_delete_object()
             .await
             .context("failed to serve `delete-object`")?;
@@ -1909,7 +1912,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1949,7 +1952,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_delete_objects()
             .await
             .context("failed to serve `delete-objects`")?;
@@ -1960,7 +1963,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -1995,7 +1998,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_get_container_data()
             .await
             .context("failed to serve `get-container-data`")?;
@@ -2006,7 +2009,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2070,7 +2073,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_get_object_info()
             .await
             .context("failed to serve `get-object-info`")?;
@@ -2081,7 +2084,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2138,7 +2141,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_has_object()
             .await
             .context("failed to serve `has-object`")?;
@@ -2149,7 +2152,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2190,7 +2193,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_move_object()
             .await
             .context("failed to serve `move-object`")?;
@@ -2201,7 +2204,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2254,7 +2257,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_blobstore::Blobstore;
 
-        let mut invocations = client
+        let invocations = client
             .serve_write_container_data()
             .await
             .context("failed to serve `move-object`")?;
@@ -2265,7 +2268,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2314,7 +2317,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_keyvalue::Eventual;
 
-        let mut invocations = client
+        let invocations = client
             .serve_delete()
             .await
             .context("failed to serve `delete`")?;
@@ -2325,7 +2328,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2357,7 +2360,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_keyvalue::Eventual;
 
-        let mut invocations = client
+        let invocations = client
             .serve_exists()
             .await
             .context("failed to serve `exists`")?;
@@ -2368,7 +2371,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2401,7 +2404,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_keyvalue::Eventual;
 
-        let mut invocations = client.serve_get().await.context("failed to serve `get`")?;
+        let invocations = client.serve_get().await.context("failed to serve `get`")?;
         try_join!(
             async {
                 let AcceptedInvocation {
@@ -2409,7 +2412,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2462,7 +2465,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_keyvalue::Eventual;
 
-        let mut invocations = client.serve_set().await.context("failed to serve `set`")?;
+        let invocations = client.serve_set().await.context("failed to serve `set`")?;
         try_join!(
             async {
                 let AcceptedInvocation {
@@ -2470,7 +2473,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2512,7 +2515,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_keyvalue::Atomic;
 
-        let mut invocations = client
+        let invocations = client
             .serve_compare_and_swap()
             .await
             .context("failed to serve `compare-and-swap`")?;
@@ -2523,7 +2526,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?
@@ -2558,7 +2561,7 @@ async fn nats() -> anyhow::Result<()> {
     {
         use wrpc_interface_keyvalue::Atomic;
 
-        let mut invocations = client
+        let invocations = client
             .serve_increment()
             .await
             .context("failed to serve `increment`")?;
@@ -2569,7 +2572,7 @@ async fn nats() -> anyhow::Result<()> {
                     result_subject,
                     transmitter,
                     ..
-                } = invocations
+                } = pin!(invocations)
                     .try_next()
                     .await
                     .context("failed to receive invocation")?


### PR DESCRIPTION
- get rid of `async_trait` usage where possible
- simplify trait bounds
- prefer stack pinning